### PR TITLE
Fix Trackpad of macos.sh: correct operations of notification center

### DIFF
--- a/system/macos.sh
+++ b/system/macos.sh
@@ -1096,9 +1096,11 @@ Trackpad() {
 
   # ========== Notification Center ==========
   # - Checked
-  defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad -int 3
+  defaults write com.apple.AppleMultitouchTrackpad TrackpadTwoFingerFromRightEdgeSwipeGesture -int 3
+  defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad TrackpadTwoFingerFromRightEdgeSwipeGesture -int 3
   # - Unchecked
-  # defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad -int 0
+  # defaults write com.apple.AppleMultitouchTrackpad TrackpadTwoFingerFromRightEdgeSwipeGesture -int 0
+  # defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad TrackpadTwoFingerFromRightEdgeSwipeGesture -int 0
 
   # ========== Mission Control ==========
   # - Checked


### PR DESCRIPTION
Fix #14

- The operations missed the option.
- The operations missed the domain of `com.apple.AppleMultitouchTrackpad`.
- The other operations of trackpad look right.

Big thanks to @solzard .